### PR TITLE
Run Inspec tests on source2adoc and source2adoc-docs images from the pipeline

### DIFF
--- a/.folderslintrc
+++ b/.folderslintrc
@@ -21,6 +21,7 @@
     "config",
     "config/dist",
     "config/dist/helm",
+    "config/etc",
 
     "docs",
     "docs/playbooks",

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -428,11 +428,52 @@ jobs:
         run: echo "CHANGE ME"
         shell: bash
 
+  inspec-baselines-rc:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    name: ${{ matrix.image-name }}
+    needs: ['publish-rc']
+    permissions:
+      contents: read
+    strategy: # see build-image (duplicated because github actions does not support anchors)
+      matrix:
+        baseline: [linux-baseline]
+        include:
+          - registry: docker.io
+            image-name: source2adoc
+          - registry: docker.io
+            image-name: source2adoc-docs
+    steps:
+      - name: Checkout Inspec baseline
+        uses: actions/checkout@v4
+        with:
+          repository: https://github.com/dev-sec/${{ matrix.baseline }}.git
+      - name: Test image ${{ matrix.registry }}/${{ secrets.DOCKERHUB_USER }}/${{ matrix.image-name }}:${{ env.IMAGE_TAG_RC }}
+        run: |
+          readlony IMAGE="${{ matrix.registry }}/${{ secrets.DOCKERHUB_USER }}/${{ matrix.image-name }}:${{ env.IMAGE_TAG_RC }}"
+          export IMAGE
+
+          docker pull "$IMAGE"
+
+          CONTAINER=$(docker run -d --entrypoint tail "$IMAGE" -f /dev/null)
+
+          readonly exclude="/^((?!os-14).)*$/"
+
+          docker run --rm \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "$(pwd):$(pwd)" \
+            --workdir "$(pwd)" \
+            chef/inspec:5.22.55 exec linux-baseline --target "docker://$container" --controls "$exclude" --chef-license=accept
+
+          docker stop --time 0 "$CONTAINER"
+          docker rm "$CONTAINER"
+        shell: bash
+
   # ----- Tag repository ------------------------
 
   release-code:
     runs-on: ubuntu-latest
-    needs: ['test-rc']
+    needs: ['test-rc', 'inspec-baselines-rc']
     if: ${{ (github.actor != 'dependabot[bot]') && (github.ref == 'refs/heads/main') }}
     permissions:
       contents: write

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -14,7 +14,7 @@
 FROM golang:1.22.6-alpine3.19 AS build
 LABEL maintainer="sebastian@sommerfeld.io"
 
-COPY /components/app /workspaces/source2adoc/components/app
+COPY components/app /workspaces/source2adoc/components/app
 WORKDIR /workspaces/source2adoc/components/app
 
 RUN pwd && ls -alF \
@@ -35,6 +35,12 @@ LABEL org.opencontainers.image.title=source2adoc \
       org.opencontainers.image.vendor="source2adoc open source project" \
       org.opencontainers.image.licenses="MIT License"
 
+# Hardening
+COPY config/etc/login.defs /etc/login.defs
+RUN chmod og-r /etc/shadow \
+    && chmod 0444 /etc/login.defs
+
+# App setup
 ARG USER=source2adoc
 RUN adduser -D "$USER"
 

--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -51,6 +51,12 @@ LABEL org.opencontainers.image.title=source2adoc-docs \
       org.opencontainers.image.vendor="source2adoc open source project" \
       org.opencontainers.image.licenses="MIT License"
 
+# Hardening
+COPY config/etc/login.defs /etc/login.defs
+RUN chmod og-r /etc/shadow \
+    && chmod 0444 /etc/login.defs
+
+# App setup
 ARG USER=www-data
 RUN chown -hR "$USER:$USER" /usr/local/apache2 \
     && chmod g-w /usr/local/apache2/conf/httpd.conf \

--- a/components/app/test/license_test.go
+++ b/components/app/test/license_test.go
@@ -1,7 +1,0 @@
-package test
-
-// Test the licenses of all Go modules and dependencies in the project.
-// Make sure the licenses are compatible with the project's MIT license.
-
-// TODO: check here as well? by running go-licenses from a test. Or is
-// TODO: that too much? Maybe just run it in CI.

--- a/config/etc/login.defs
+++ b/config/etc/login.defs
@@ -1,0 +1,30 @@
+# /etc/login.defs - Configuration control definitions for the login package.
+# https://man7.org/linux/man-pages/man5/login.defs.5.html
+
+ENV_PATH    "/usr/local/bin:/usr/bin:/bin"
+ENV_SUPATH  "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+DEFAULT_HOME	yes
+
+PASS_MAX_DAYS	60
+PASS_MIN_DAYS	7
+PASS_WARN_AGE	7
+
+LOGIN_RETRIES   5
+LOGIN_TIMEOUT   60
+
+# Min/max values for automatic uid selection in useradd
+UID_MIN			 1000
+UID_MAX			60000
+
+# Min/max values for automatic gid selection in groupadd
+GID_MIN			 1000
+GID_MAX			60000
+
+CREATE_HOME	yes
+
+UMASK           027
+
+USERGROUPS_ENAB yes
+
+ENCRYPT_METHOD SHA512

--- a/inspec.sh
+++ b/inspec.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+## Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt
+## ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo
+## dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor
+## sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+## invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et
+## justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est.
+
+
+# docker run --name source2adoc -d --entrypoint tail sommerfeldio/source2adoc:rc -f /dev/null
+# docker run --name source2adoc -d --entrypoint tail sommerfeldio/source2adoc-docs:rc -f /dev/null
+
+docker build -t local/source2adoc:dev -f Dockerfile.app --no-cache .
+container=$(docker run -d --entrypoint tail local/source2adoc:dev -f /dev/null)
+export container
+
+# docker build -t local/source2adoc-docs:dev -f Dockerfile.docs --no-cache .
+# docker run --name source2adoc_docs -d --entrypoint tail local/source2adoc-docs:dev -f /dev/null
+
+(
+    cd /tmp || exit
+    
+    rm -rf linux-baseline
+    git clone https://github.com/dev-sec/linux-baseline
+
+    readonly exclude="/^((?!os-14).)*$/"
+
+    docker run --rm \
+        --volume /var/run/docker.sock:/var/run/docker.sock \
+        --volume /workspaces/source2adoc/.inspec.yml:/workspaces/source2adoc/.inspec.yml:ro \
+        --volume "$(pwd):$(pwd)" \
+        --workdir "$(pwd)" \
+        chef/inspec:5.22.55 exec linux-baseline --target "docker://$container" --controls "$exclude" --chef-license=accept
+    
+    docker stop --time 0 "$container"
+    docker rm "$container"
+
+    # docker run --rm \
+    #     --volume /var/run/docker.sock:/var/run/docker.sock \
+    #     --volume /workspaces/source2adoc/.inspec.yml:/workspaces/source2adoc/.inspec.yml:ro \
+    #     --volume "$(pwd):$(pwd)" \
+    #     --workdir "$(pwd)" \
+    #     chef/inspec:5.22.55 exec linux-baseline --target docker://source2adoc_docs --controls "$exclude" --chef-license=accept
+    
+    # docker stop --time 0 source2adoc_docs
+    # docker rm source2adoc_docs
+)


### PR DESCRIPTION
This pull request introduces Chef InSpec tests for the `source2adoc` and `source2adoc-docs` images. These tests are essential for ensuring the security and compliance of the images in our environment.

Specifically, the tests are based on the [Linux Baseline](https://dev-sec.io/baselines/linux/) profile: Provides a comprehensive set of controls to validate the security of Linux-based systems. This ensures that the source2adoc and source2adoc-docs images comply with industry-standard security practices, covering aspects such as user permissions, system configurations, and more.

By integrating these InSpec profiles into our CI/CD pipeline, we can automatically verify that our images are compliant with security baselines before they are deployed, enhancing our overall security posture.